### PR TITLE
[mosip/mosip-infra#1890] Added domainConfig support in partner-onboarder helm chart

### DIFF
--- a/helm/partner-onboarder/templates/jobs.yaml
+++ b/helm/partner-onboarder/templates/jobs.yaml
@@ -45,6 +45,10 @@ spec:
             {{- if $.Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" $.Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+            {{- range $key, $val := $.Values.domainConfig }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
 
           envFrom:
             {{- if $.Values.onboarding.configmaps }}

--- a/helm/partner-onboarder/values.yaml
+++ b/helm/partner-onboarder/values.yaml
@@ -214,6 +214,15 @@ backoffLimit: 0
 ##
 updateStrategy:
   type: RollingUpdate
+
+## Domain-specific environment variables injected into the Job container.
+## Values are passed as individual env vars (merged map, not a list — safe to override partially).
+## Example:
+##   domainConfig:
+##     MOSIP_API_INTERNAL_HOST: api-internal.sandbox.xyz.net
+##     MOSIP_ESIGNET_HOST: esignet.sandbox.xyz.net
+domainConfig: {}
+
 ## Additional environment variables to set
 ## Example:
 ## extraEnvVars:
@@ -412,7 +421,7 @@ onboarding:
       ns_signup: signup
   secrets:
     s3:
-      s3-user-secret: 'password'
+      s3-user-secret: ''
   volumes:
     reports:
       name: onboarder-reports


### PR DESCRIPTION
## Summary

- Added `domainConfig` map in `helm/partner-onboarder/values.yaml`
- Added `domainConfig` range loop in `helm/partner-onboarder/templates/jobs.yaml` to inject domain values as individual env vars into Job containers
- Cleared default value for `s3-user-secret`

## Related Issue
mosip/mosip-infra#1890

## Test plan
- [ ] Helm template renders correctly with `domainConfig` values set
- [ ] Domain env vars present in partner-onboarder Job pod