### PR TITLE
#10670: Add AGENTS.md for AI coding assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,16 +137,18 @@ environment and inspecting the generated HTML reports under `./reports`.
 ├── onboarding.postman_environment.json  # Postman environment (patched at runtime)
 ├── onboarding.properties           # blank template of per-environment/partner values
 ├── default-*-policy.json           # default auth/datashare/oidc/misp policy documents
-├── certs/                          # default root/client certs per module + cert helper scripts
-├── deploy/                         # cluster install helpers (install.sh, copy_cm.sh, copy_secrets.sh, values.yaml)
-├── helm/partner-onboarder/         # Helm chart that runs onboarding as a Kubernetes Job
+├── certs/                          # default root/client certs per module + cert helper scripts — certs/AGENTS.md
+├── deploy/                         # cluster install helpers (install.sh, copy_cm.sh, copy_secrets.sh, values.yaml) — deploy/AGENTS.md
+├── helm/partner-onboarder/         # Helm chart that runs onboarding as a Kubernetes Job — helm/AGENTS.md
 └── .github/workflows/              # CI: docker build, chart lint/publish, tag/release
 ```
 
 This is a flat, single-purpose repo — there is no separate frontend/backend
-split and no module that warrants its own `AGENTS.md`. `deploy/README.md`
-and `helm/partner-onboarder/README.md` already document their own
-directories; this root file is the single source of truth for agents.
+split. `certs/`, `deploy/`, and `helm/` each have their own `AGENTS.md`
+with subfolder-specific detail; `licenses/` holds only static license
+text and doesn't need one. `deploy/README.md` and
+`helm/partner-onboarder/README.md` document their own directories too —
+this root file is the shared source of truth across all of them.
 
 ## Development Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,237 @@
+# AGENTS.md
+
+## Repository Overview
+
+`mosip-onboarding` (also called **partner-onboarder**) is a shell-script and
+Postman-collection based utility that onboards default MOSIP partners into a
+running MOSIP environment. It is not an application with source code to
+compile — it is an automation/config repo. It:
+
+- Creates Keycloak partner users and uploads partner/root certificates for
+  modules such as IDA, Print, ABIS, Resident, Mobile-ID, Digital Card,
+  eSignet, Demo-OIDC, Resident-OIDC, and Mimoto keybinding.
+- Runs its API calls through a Postman collection
+  (`onboarding.postman_collection.json`) driven by `newman` (the Postman CLI
+  runner).
+- Generates HTML onboarding reports and optionally uploads them to a MinIO/S3
+  bucket.
+- Ships a Docker image and a Helm chart so onboarding can run as a
+  Kubernetes Job.
+
+See `README.md` for the human-facing overview and prerequisites.
+
+## Technology Stack
+
+- **Shell scripts** (`bash`/`sh`) — the actual onboarding logic
+  (`default.sh`, `run-onboarding.sh`, `entrypoint.sh`, `upload-reports.sh`,
+  `deploy/*.sh`, `certs/*.sh`).
+- **Newman** (Postman CLI) with the `newman-reporter-htmlextra` reporter —
+  executes `onboarding.postman_collection.json` against
+  `onboarding.postman_environment.json`.
+- **Docker** — base image `node:lts-alpine3.17`, with `newman`,
+  `newman-reporter-htmlextra`, and `pem-jwk` installed globally via `npm`,
+  plus `curl`, `openssl`, `jq`, the MinIO client (`mc`), and `kubectl`
+  installed via `apk`/`curl` (see `Dockerfile`).
+- **Helm** — chart at `helm/partner-onboarder` for running onboarding as a
+  Kubernetes Job.
+- **jq** — used throughout the shell scripts to patch the Postman
+  environment JSON file in place.
+
+There is no `pom.xml`, `package.json` (application-level), or Java/Maven
+build in this repo — do not assume a JVM build process here.
+
+## Build & Test Commands
+
+Build the Docker image:
+
+```shell
+./docker-build.sh
+```
+
+This runs `docker build -t mosipdev/partner-onboarder:develop .`.
+
+Run the image locally (example from `docker-run.sh` — replace the
+placeholder value before running):
+
+```shell
+CERT_MANAGER_PASSWORD="your-mosip-deployment-client-password"
+docker run --rm --name partner-onboarder -p 8080:8080 \
+  -e URL=https://api-internal.soil.mosip.net \
+  -e CERT_MANAGER_PASSWORD="$CERT_MANAGER_PASSWORD" \
+  mosipdev/partner-onboarder:develop
+```
+
+Run onboarding directly with the shell script (outside Docker), after
+exporting the required environment variables:
+
+```shell
+export URL="https://api-internal.example.mosip.net"
+export CERT_MANAGER_PASSWORD="your-mosip-deployment-client-secret"
+./default.sh
+```
+
+There is no automated unit/integration test suite in this repo. Validation
+happens by running the onboarding flow against a real (or sandbox) MOSIP
+environment and inspecting the generated HTML reports under `./reports`.
+
+## Configuration
+
+- `onboarding.properties` — template of partner/module properties (Keycloak
+  URLs, admin/partner credentials, policy names, certificate subject fields,
+  etc.). All values are left blank in the tracked file; they must be filled
+  in per-environment before running `run-onboarding.sh`. **Never commit a
+  filled-in copy of this file** — it holds Keycloak admin and partner
+  passwords.
+- `onboarding.postman_environment.json` — Postman environment consumed by
+  `newman`; `default.sh`/`run-onboarding.sh` patch values into a **copy**
+  of this file with `jq` at runtime (see `default.sh`'s `update_props`
+  function). Do not commit a version of this file populated with real
+  secrets.
+- `deploy/values.yaml` — controls which modules are enabled for a Helm-chart
+  onboarding run (`ida`, `print`, `abis`, `resident`, `mobileid`,
+  `digitalcard`, `esignet`, `demo-oidc`, `resident-oidc`,
+  `mimoto-keybinding`).
+- `helm/partner-onboarder/values.yaml` — the chart's default values,
+  overridden by `deploy/values.yaml` and by `--set` flags in
+  `deploy/install.sh`.
+- Docker environment variables consumed by `entrypoint.sh`/`default.sh`
+  include `URL`, `CERT_MANAGER_PASSWORD`, `ENABLE_INSECURE`, `MODULE`,
+  the `s3-*` variables (S3/MinIO host, region, key, secret, bucket) and
+  `ns_mimoto` / `ns_esignet` (see `Dockerfile` `ENV` block).
+- `deploy/copy_cm.sh` and `deploy/copy_secrets.sh` download a helper script
+  (`copy_cm_func.sh`) from `mosip-infra` at runtime and use it to copy
+  Kubernetes ConfigMaps/Secrets (`s3`, `keycloak`, `keycloak-client-secrets`,
+  `global`, `keycloak-env-vars`, `keycloak-host`) into the `onboarder`
+  namespace — do not hand-copy these values into files in this repo.
+- `certs/` holds sample/default root and client certificates per module
+  (`abis`, `mpartner-default-mobile`, `print`); each `*-inline.pem` is the
+  same certificate as its sibling `.pem` but flattened to a single line —
+  per `certs/README.md`, if you change one you must regenerate the other
+  (see `certs/convert.sh`).
+
+## Project Structure Notes
+
+```text
+.
+├── default.sh                     # main onboarding driver, calls newman per module/cert
+├── run-onboarding.sh               # reads onboarding.properties, patches the postman env, invokes newman
+├── entrypoint.sh                   # Docker ENTRYPOINT: runs default.sh then upload-reports.sh
+├── upload-reports.sh               # optionally pushes ./reports to MinIO/S3 via `mc`
+├── docker-build.sh / docker-run.sh # local Docker build/run helpers
+├── Dockerfile                      # node:lts-alpine3.17 based image with newman, kubectl, mc, jq
+├── onboarding.postman_collection.json   # Postman collection with all onboarding API calls
+├── onboarding.postman_environment.json  # Postman environment (patched at runtime)
+├── onboarding.properties           # blank template of per-environment/partner values
+├── default-*-policy.json           # default auth/datashare/oidc/misp policy documents
+├── certs/                          # default root/client certs per module + cert helper scripts
+├── deploy/                         # cluster install helpers (install.sh, copy_cm.sh, copy_secrets.sh, values.yaml)
+├── helm/partner-onboarder/         # Helm chart that runs onboarding as a Kubernetes Job
+└── .github/workflows/              # CI: docker build, chart lint/publish, tag/release
+```
+
+This is a flat, single-purpose repo — there is no separate frontend/backend
+split and no module that warrants its own `AGENTS.md`. `deploy/README.md`
+and `helm/partner-onboarder/README.md` already document their own
+directories; this root file is the single source of truth for agents.
+
+## Development Workflow
+
+1. Fork and clone the repo, then create a feature branch off `develop`
+   (this repo develops on `develop`, not the reported default branch).
+2. Make changes to the shell scripts, Postman collection, policy JSON
+   files, or Helm chart as needed.
+3. If you change `onboarding.postman_collection.json`, validate it opens
+   correctly in Postman/Newman and that folder names referenced by
+   `default.sh` (e.g. `authenticate-as-cert-manager`,
+   `download-ida-certificate`, `upload-ca-certificate`) still exist — those
+   folder names are called out explicitly by `--folder` flags in the shell
+   scripts and a rename will silently break onboarding.
+4. If you change the Helm chart under `helm/partner-onboarder/`, keep
+   `Chart.yaml`'s version in sync with expectations of
+   `.github/workflows/chart-lint-publish.yml`, which lints/publishes charts
+   under `helm/**` on PRs and pushes to `develop`/`release*`/`1.*`/`0.*`.
+5. Test locally by building the Docker image (`./docker-build.sh`) and
+   running it against a sandbox MOSIP environment, or by exporting `URL`
+   and `CERT_MANAGER_PASSWORD` and running `./default.sh` directly, then
+   inspect the HTML reports under `./reports`.
+6. Do not commit real credentials, filled-in `onboarding.properties`, or a
+   populated `onboarding.postman_environment.json`.
+
+## Pull Request Guidelines
+
+- Target the `develop` branch (this repo's real integration branch — GitHub
+  reports `master` as the default branch, but active development happens on
+  `develop`).
+- Keep commits scoped to one logical change (a module's onboarding flow,
+  the Helm chart, the Docker image, etc.).
+- CI (`.github/workflows/push-trigger.yml`) builds and publishes the
+  `partner-onboarder` Docker image on pushes to `develop`, `release*`,
+  `1.*`, `master`, `MOSIP*` branches and on PR open/reopen/sync — make sure
+  the Docker build (`docker-build.sh`/`Dockerfile`) still succeeds.
+- If you touch anything under `helm/`, expect
+  `.github/workflows/chart-lint-publish.yml` to lint the chart on your PR.
+- Reference the tracking issue number in the PR title/description when one
+  exists.
+
+## Repository-Specific Considerations
+
+- Almost all "logic" here is bash string/JSON manipulation with `jq` against
+  Postman JSON files — small formatting mistakes (missing `mv` of the temp
+  file, mismatched `--env-var` names) will silently break a downstream
+  `newman` call rather than fail loudly. Check that every `jq ... > tmp &&
+  mv tmp <file>` pattern is preserved when editing `run-onboarding.sh` or
+  `default.sh`.
+- `deploy/copy_cm.sh` and `deploy/copy_secrets.sh` fetch
+  `copy_cm_func.sh` from the `master` branch of `mosip/mosip-infra` at
+  runtime — changes to that external script can affect this repo's install
+  flow without any change here.
+- `deploy/install.sh` and `default.sh`/`run-onboarding.sh` are interactive
+  (they use `read -p` prompts) — they are not meant to run unattended in
+  CI; only the Docker image path (`entrypoint.sh` → `default.sh` →
+  `upload-reports.sh`) is meant for non-interactive/automated execution.
+- The `ENABLE_INSECURE` flag exists specifically for servers without a
+  public domain/valid SSL certificate (self-signed cert scenarios); it is
+  documented as **not** recommended outside development environments.
+- `onboarding.postman_environment.json` and `onboarding.properties` are
+  templates checked into the repo with blank secret fields — treat any
+  filled-in version as a secret file and keep it out of commits (`.gitignore`
+  already excludes the `tmp` and `reports` working directories that scripts
+  generate at runtime).
+
+## Agent rules
+
+### Do
+
+1. Verify any shell script or workflow behavior against the actual file in
+   this repo before describing or relying on it — this repo has many
+   near-duplicate `default-*.sh`/`upload_*` functions in `default.sh`; check
+   the specific one you're touching.
+2. Preserve the `jq ... > $(prop 'tmp_dir')/tmp.json && mv ...` pattern when
+   editing property-patching logic in `run-onboarding.sh` or `default.sh`.
+3. Target the `develop` branch for PRs and branch from `upstream/develop`.
+4. Keep `onboarding.properties` and `onboarding.postman_environment.json`
+   free of real credentials in any commit.
+5. Update `certs/*-inline.pem` alongside its corresponding `certs/*.pem`
+   whenever you change a certificate (per `certs/README.md`).
+6. Run `docker-build.sh` (or otherwise validate the `Dockerfile`) after
+   changing any `*.sh` or `*.json` file copied into the image, since the
+   `Dockerfile` copies scripts and JSON files explicitly (`COPY *.json`,
+   `COPY *.sh`).
+
+### Do not
+
+1. Do not assume this repo has a Java/Maven or Node application build —
+   there isn't one; the Docker image only installs `newman` and CLI tools
+   globally.
+2. Do not rename or restructure Postman collection folders
+   (`authenticate-as-cert-manager`, `download-ida-certificate`,
+   `upload-ca-certificate`, `upload-leaf-certificate`,
+   `upload-signed-leaf-certificate`, etc.) without updating every `--folder`
+   reference to them in `default.sh`.
+3. Do not commit filled-in secrets/credentials into `onboarding.properties`,
+   `onboarding.postman_environment.json`, or any new config file.
+4. Do not add automated tests or CI test steps that assume a live MOSIP
+   environment is reachable — none of the current workflows do this, and
+   onboarding scripts are interactive and environment-dependent by design.
+5. Do not push branches to the `upstream` MOSIP remote — push to your own
+   fork (`origin`) and open a PR from there.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,10 +56,17 @@ placeholder value before running):
 ```shell
 CERT_MANAGER_PASSWORD="your-mosip-deployment-client-password"
 docker run --rm --name partner-onboarder -p 8080:8080 \
+  -v "$PWD/reports:/home/mosip/reports" \
   -e URL=https://api-internal.soil.mosip.net \
   -e CERT_MANAGER_PASSWORD="$CERT_MANAGER_PASSWORD" \
   mosipdev/partner-onboarder:develop
 ```
+
+Mounting `./reports` is required — `default.sh` writes reports to a
+relative `./reports/...` path (i.e. under the Dockerfile's
+`WORKDIR /home/${container_user}`, `mosip` by default), and `--rm`
+deletes the container (and anything not mounted out of it) once it
+exits.
 
 Run onboarding directly with the shell script (outside Docker), after
 exporting the required environment variables:
@@ -99,10 +106,17 @@ environment and inspecting the generated HTML reports under `./reports`.
   the `s3-*` variables (S3/MinIO host, region, key, secret, bucket) and
   `ns_mimoto` / `ns_esignet` (see `Dockerfile` `ENV` block).
 - `deploy/copy_cm.sh` and `deploy/copy_secrets.sh` download a helper script
-  (`copy_cm_func.sh`) from `mosip-infra` at runtime and use it to copy
-  Kubernetes ConfigMaps/Secrets (`s3`, `keycloak`, `keycloak-client-secrets`,
-  `global`, `keycloak-env-vars`, `keycloak-host`) into the `onboarder`
-  namespace — do not hand-copy these values into files in this repo.
+  (`copy_cm_func.sh`) from the **mutable `master` branch** of
+  `mosip-infra` at runtime, with no checksum/signature verification, and
+  execute it to copy Kubernetes ConfigMaps/Secrets (`s3`, `keycloak`,
+  `keycloak-client-secrets`, `global`, `keycloak-env-vars`,
+  `keycloak-host`) into the `onboarder` namespace. This is a real
+  supply-chain risk, not just a reliability concern: a compromised or
+  rewritten `mosip-infra` `master` would have its script executed
+  against the target cluster's Secrets/ConfigMaps on the next run,
+  unpinned and unverified. Do not hand-copy these values into files in
+  this repo, and don't propagate the same fetch-and-exec-from-mutable-
+  branch pattern into any new script.
 - `certs/` holds sample/default root and client certificates per module
   (`abis`, `mpartner-default-mobile`, `print`); each `*-inline.pem` is the
   same certificate as its sibling `.pem` but flattened to a single line —
@@ -136,8 +150,11 @@ directories; this root file is the single source of truth for agents.
 
 ## Development Workflow
 
-1. Fork and clone the repo, then create a feature branch off `develop`
-   (this repo develops on `develop`, not the reported default branch).
+1. Fork and clone the repo, add `upstream` pointing at
+   `mosip/mosip-onboarding`, fetch `upstream/develop`, then create a
+   feature branch from `upstream/develop` — not a stale local `develop`
+   or your fork's `develop` (this repo develops on `develop`, not the
+   reported default branch).
 2. Make changes to the shell scripts, Postman collection, policy JSON
    files, or Helm chart as needed.
 3. If you change `onboarding.postman_collection.json`, validate it opens
@@ -148,8 +165,11 @@ directories; this root file is the single source of truth for agents.
    scripts and a rename will silently break onboarding.
 4. If you change the Helm chart under `helm/partner-onboarder/`, keep
    `Chart.yaml`'s version in sync with expectations of
-   `.github/workflows/chart-lint-publish.yml`, which lints/publishes charts
-   under `helm/**` on PRs and pushes to `develop`/`release*`/`1.*`/`0.*`.
+   `.github/workflows/chart-lint-publish.yml`. It **lints** charts under
+   `helm/**` on PRs; actual publishing to the `gh-pages` branch only
+   happens via a manual `workflow_dispatch` run with
+   `CHART_PUBLISH=YES` (or on a published release), not automatically
+   on every PR or push.
 5. Test locally by building the Docker image (`./docker-build.sh`) and
    running it against a sandbox MOSIP environment, or by exporting `URL`
    and `CERT_MANAGER_PASSWORD` and running `./default.sh` directly, then
@@ -164,12 +184,18 @@ directories; this root file is the single source of truth for agents.
   `develop`).
 - Keep commits scoped to one logical change (a module's onboarding flow,
   the Helm chart, the Docker image, etc.).
-- CI (`.github/workflows/push-trigger.yml`) builds and publishes the
-  `partner-onboarder` Docker image on pushes to `develop`, `release*`,
-  `1.*`, `master`, `MOSIP*` branches and on PR open/reopen/sync — make sure
-  the Docker build (`docker-build.sh`/`Dockerfile`) still succeeds.
+- CI (`.github/workflows/push-trigger.yml`) **builds** the
+  `partner-onboarder` Docker image (via the shared `mosip/kattu`
+  reusable workflow) on pushes to `develop`, `release*`, `1.*`,
+  `master`, `MOSIP*` branches and on PR open/reopen/sync — make sure
+  the Docker build (`docker-build.sh`/`Dockerfile`) still succeeds. Do
+  not assume a PR also **publishes** the image; that reusable workflow
+  is not documented in this repo, so don't state its publish behavior
+  without checking `mosip/kattu` directly.
 - If you touch anything under `helm/`, expect
-  `.github/workflows/chart-lint-publish.yml` to lint the chart on your PR.
+  `.github/workflows/chart-lint-publish.yml` to **lint** the chart on
+  your PR — it does not publish from a PR (see Development Workflow
+  above).
 - Reference the tracking issue number in the PR title/description when one
   exists.
 
@@ -182,9 +208,10 @@ directories; this root file is the single source of truth for agents.
   mv tmp <file>` pattern is preserved when editing `run-onboarding.sh` or
   `default.sh`.
 - `deploy/copy_cm.sh` and `deploy/copy_secrets.sh` fetch
-  `copy_cm_func.sh` from the `master` branch of `mosip/mosip-infra` at
-  runtime — changes to that external script can affect this repo's install
-  flow without any change here.
+  `copy_cm_func.sh` from the mutable `master` branch of
+  `mosip/mosip-infra` at runtime with no integrity check — see the
+  Configuration section above for why this is a supply-chain risk, not
+  just a reliability one.
 - `deploy/install.sh` and `default.sh`/`run-onboarding.sh` are interactive
   (they use `read -p` prompts) — they are not meant to run unattended in
   CI; only the Docker image path (`entrypoint.sh` → `default.sh` →
@@ -213,10 +240,13 @@ directories; this root file is the single source of truth for agents.
    free of real credentials in any commit.
 5. Update `certs/*-inline.pem` alongside its corresponding `certs/*.pem`
    whenever you change a certificate (per `certs/README.md`).
-6. Run `docker-build.sh` (or otherwise validate the `Dockerfile`) after
-   changing any `*.sh` or `*.json` file copied into the image, since the
-   `Dockerfile` copies scripts and JSON files explicitly (`COPY *.json`,
-   `COPY *.sh`).
+6. Run `./docker-build.sh` (an actual build, not just a static read of
+   the `Dockerfile`) after changing any `*.sh` or `*.json` file copied
+   into the image, since the `Dockerfile` copies scripts and JSON files
+   explicitly (`COPY *.json`, `COPY *.sh`) — static inspection won't
+   catch a missing copied file, a dependency-install failure, or an
+   entrypoint error. Validate the actual onboarding flow too where
+   practical, since it depends on the target environment.
 
 ### Do not
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ placeholder value before running):
 CERT_MANAGER_PASSWORD="your-mosip-deployment-client-password"
 docker run --rm --name partner-onboarder -p 8080:8080 \
   -v "$PWD/reports:/home/mosip/reports" \
-  -e URL=https://api-internal.soil.mosip.net \
+  -e URL="https://api-internal.example.mosip.net" \
   -e CERT_MANAGER_PASSWORD="$CERT_MANAGER_PASSWORD" \
   mosipdev/partner-onboarder:develop
 ```

--- a/certs/AGENTS.md
+++ b/certs/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md — certs/
+
+Parent guide: [`../AGENTS.md`](../AGENTS.md)
+
+## Purpose
+
+Sample/default root and client certificates for onboarding modules
+(`abis`, `mpartner-default-mobile`, `print`), plus the OpenSSL/shell
+tooling used to generate or convert them. **These are test/reference
+certs, not for production** — `create-signing-certs.sh`'s own header
+says so explicitly.
+
+## Layout
+
+```text
+certs/
+├── README.md                        # one-line note: keep *-inline.pem in sync with its .pem sibling
+├── abis/                              client.pem, client-inline.pem, root-ca.pem, root-ca-inline.pem
+├── mpartner-default-mobile/             client.pem, client-inline.pem, root-ca.pem, root-ca-inline.pem
+├── print/                                 client.pem, client-inline.pem, root-ca.pem, root-ca-inline.pem
+├── client-openssl.cnf, root-openssl.cnf     # OpenSSL config templates used by the create-signing-certs scripts
+├── demo-oidc-policy.json                      # sample OIDC policy JSON
+├── convert.sh                                   # exports a cert from a keystore and converts its public key to JWK
+├── create-jwks.sh                                 # fetches the current cert from a live keymanager and converts to JWK
+├── create-signing-certs.sh                          # generates a self-signed root+client cert pair (2048-bit RSA) — reference/test only
+└── create-signing-certs(4096).sh                      # same as above, 4096-bit RSA keys instead of 2048
+```
+
+## Key scripts
+
+- **`create-signing-certs.sh`** / **`create-signing-certs(4096).sh`** —
+  generate a self-signed root CA and client certificate for a partner
+  (`PARTNER_KC_USERNAME` env var), using `root-openssl.cnf`/
+  `client-openssl.cnf`. The two files are identical except for RSA key
+  size (2048 vs. 4096 bits) — if you fix a bug in one, apply the same
+  fix to the other; they are not generated from a shared template.
+- **`convert.sh`** — given a partner's keystore (`keystore.p12` under
+  `<path>/certs/<partner>/`) and a password read from a local `key.pwd`
+  file, exports the client cert, converts its public key to JWK format
+  (via the `pem-jwk` npm tool), and writes `publickey.jwk` back into
+  that partner's cert directory.
+- **`create-jwks.sh`** — authenticates against a live MOSIP Authmanager/
+  Keymanager (`mosip-api-internal-host` env var,
+  `mosip_deployment_client_secret` env var) to fetch the **current
+  server-side certificate** for `RESIDENT`, then converts its public
+  key to JWK. This one talks to a real running environment, unlike
+  `convert.sh` and the `create-signing-certs*.sh` scripts, which only
+  operate on local files.
+
+## Configuration
+
+- `*-inline.pem` files are the same certificate as their sibling
+  `.pem` file, flattened to a single line with literal `\n` escapes —
+  regenerate one from the other with `convert.sh` (or by hand) whenever
+  either changes; they are not auto-synced.
+- `create-jwks.sh` and `convert.sh` both depend on the `pem-jwk` npm
+  package being installed globally (`npm install -g pem-jwk`, commented
+  out in both scripts — install it yourself before running them).
+- No real credentials belong in this directory — `create-jwks.sh`'s
+  `mosip_deployment_client_secret` and `convert.sh`'s `key.pwd` file
+  are supplied locally at runtime, never committed.
+
+## Agent rules
+
+### Do
+
+1. Update the matching `*-inline.pem` whenever you change a `.pem` file
+   in this directory (see root `AGENTS.md`).
+2. Apply any fix made in `create-signing-certs.sh` to
+   `create-signing-certs(4096).sh` too, and vice versa — they're
+   maintained as two near-duplicate files, not one shared script.
+3. Treat certs generated here as test/reference material — never point
+   these scripts at a production MOSIP environment's real signing keys.
+
+### Do not
+
+1. Do not commit a real `key.pwd`, keystore, or `mosip_deployment_client_secret`
+   value used by `convert.sh`/`create-jwks.sh`.
+2. Do not assume `create-jwks.sh` is a local-only tool — it makes real
+   HTTP calls to `mosip-api-internal-host` and requires a reachable,
+   authenticated MOSIP environment.

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -1,0 +1,96 @@
+# AGENTS.md — deploy/
+
+Parent guide: [`../AGENTS.md`](../AGENTS.md)
+
+## Purpose
+
+Interactive shell scripts and `values.yaml` that install/delete the
+`mosip/partner-onboarder` Helm release (backed by `../helm/partner-onboarder/`)
+into the `onboarder` namespace, running the Docker image's onboarding
+flow as a Kubernetes Job.
+
+## Layout
+
+```text
+deploy/
+├── README.md         # overview, install steps, post-onboarding config steps
+├── install.sh           # interactive first-time install — see below
+├── copy_cm.sh              # copies ConfigMaps (global, keycloak-env-vars, keycloak-host) into onboarder
+├── copy_secrets.sh           # copies Secrets (s3, keycloak, keycloak-client-secrets) into onboarder
+├── delete.sh                    # interactive helm uninstall (prompts Y/n)
+└── values.yaml                     # which onboarding modules are enabled — see below
+```
+
+## Script details
+
+- **`install.sh`** — the most involved script in this repo. In order:
+  prompts (Y/n) whether you have a public domain + valid SSL cert
+  (**this exact prompt block is duplicated twice in a row** near the
+  top of the file — a pre-existing repo quirk, not something to "fix"
+  by deleting the second copy without checking it isn't relied on by
+  something else); creates the `onboarder` namespace; asks for
+  confirmation that `values.yaml` is set correctly; labels the
+  namespace `istio-injection=disabled` (note: `disabled`, not
+  `enabled` — differs from some other MOSIP repos, don't assume a
+  repo-wide convention); deletes and recreates the `s3`/
+  `onboarder-namespace` ConfigMaps via `copy_cm.sh`; runs
+  `copy_secrets.sh`; interactively prompts for the S3 bucket
+  name/region/URL (rejecting values with spaces or special
+  characters); reads `s3-user-key` from the `s3` namespace's `s3`
+  ConfigMap; `helm install`s `mosip/partner-onboarder` pinned to
+  `CHART_VERSION=0.0.1-develop`; then prints a link to
+  `mosip-infra`'s `partner-onboarder/README.md#configuration` for the
+  manual post-onboarding mimoto-keybinding steps, built from the
+  **current git branch name** (`git symbolic-ref --short HEAD`) — if
+  you're on a branch that doesn't exist in `mosip-infra`, that link
+  will 404; don't assume it always resolves.
+  `set -e`/`set -o nounset`/`set -o pipefail` are only enabled at the
+  very bottom of the file, right before `installing_onboarder` is
+  called — namespace creation and all the interactive prompts run
+  without those options active.
+- **`copy_cm.sh`** / **`copy_secrets.sh`** — both independently
+  download `copy_cm_func.sh` from the **mutable `master` branch** of
+  `mosip/mosip-infra` at runtime with no integrity check, then use it
+  to copy the ConfigMaps/Secrets listed above. See root `AGENTS.md`'s
+  Configuration section for why this is a supply-chain risk, not just
+  a reliability one — the same pattern is duplicated in both scripts
+  rather than shared.
+- **`delete.sh`** — interactive-only (no non-interactive/CI-safe flag);
+  loops prompting "Are you sure you want to delete all
+  partner-onboarder? (Y/n)" until `Y` is entered, then runs
+  `helm -n onboarder delete partner-onboarder`.
+
+## Configuration
+
+`values.yaml` toggles which onboarding modules run
+(`onboarding.modules[].{name,enabled}`): `ida`, `print`, `abis`,
+`resident`, `mobileid` are enabled by default; `digitalcard`, `esignet`,
+`demo-oidc`, `resident-oidc`, `mimoto-keybinding` are not (see
+`../AGENTS.md`'s Configuration section for the full list). Edit this
+file, not `../helm/partner-onboarder/values.yaml`, to control which
+modules an install run actually onboards — `install.sh` passes
+`-f values.yaml` explicitly.
+
+## Agent rules
+
+### Do
+
+1. Read `README.md`'s post-onboarding "Configurational steps" section
+   before assuming `install.sh` alone completes onboarding — the
+   mimoto-keybinding partner step requires a manual follow-up outside
+   this script.
+2. Keep `copy_cm.sh` and `copy_secrets.sh`'s `copy_cm_func.sh` fetch
+   logic in sync if you change one — they're independent copies of the
+   same pattern, not a shared function.
+
+### Do not
+
+1. Do not assume the printed `mosip-infra` documentation link in
+   `install.sh` always resolves — it's built from the current git
+   branch name, which may not exist in that other repo.
+2. Do not remove the duplicated Y/n prompt block in `install.sh`
+   without confirming it's actually redundant — it may be a bug, but
+   verify before "fixing" it as a drive-by change.
+3. Do not add a non-interactive flag to `delete.sh` without discussing
+   it — the confirmation loop is the only guard against an accidental
+   delete.

--- a/helm/AGENTS.md
+++ b/helm/AGENTS.md
@@ -1,0 +1,86 @@
+# AGENTS.md — helm/
+
+Parent guide: [`../AGENTS.md`](../AGENTS.md)
+
+## Purpose
+
+The `partner-onboarder` Helm chart — runs the Docker image
+(`../Dockerfile`) as one Kubernetes Job per enabled onboarding module.
+Installed by `../deploy/install.sh`.
+
+## Layout
+
+```text
+helm/partner-onboarder/
+├── Chart.yaml       # name "partner-onboarder", depends on Bitnami common
+├── README.md          # generic chart-starter boilerplate — see caveat below
+├── values.yaml           # chart defaults — see below for the module-list caveat
+├── .helmignore
+└── templates/               # not fully explored here; jobs.yaml and pvc.yaml both
+                              # `range` over .Values.onboarding.modules (see below)
+```
+
+## `values.yaml` — the module-list override caveat
+
+`values.yaml`'s own `onboarding.modules` list (12 entries, all
+`enabled: false` by default, including `mimoto`, `mock-rp-oidc`,
+`mimoto-oidc`, `signup-oidc`) uses **different module names** than
+`../deploy/values.yaml`'s list (10 entries, including `mobileid` and
+`demo-oidc` instead). This looks like a mismatch, but it isn't a bug in
+practice: `../deploy/install.sh` always passes `-f values.yaml`
+(deploy's file), and Helm's default `-f` merge behavior **replaces a
+YAML list wholesale** rather than merging entries by name — so
+`../deploy/values.yaml`'s module list is what actually gets used; this
+chart's own `values.yaml` module list is effectively just a
+placeholder/example that a plain `helm install` without `-f` would fall
+back to. When changing which modules run, edit `../deploy/values.yaml`,
+not this file — see `../deploy/AGENTS.md`.
+
+`templates/jobs.yaml` and `templates/pvc.yaml` both
+`range $module := $.Values.onboarding.modules`, creating one Job/PVC
+entry per module in whichever list actually won the merge. If you add a
+new module, add it to **both** `values.yaml` files' `onboarding.modules`
+lists (with matching `name` values) to keep the chart's own defaults
+usable standalone.
+
+Other `values.yaml` sections: `image.repository`/`.tag`
+(`mosipqa/partner-onboarder:develop`), an `os-shell` init-container
+image (`mosipid/os-shell:12-debian-12-r46`), `onboarding.configmaps`
+(S3 host/user-key/region defaults, `onboarder-namespace` mappings for
+`ns_mimoto`/`ns_esignet`/`ns_signup`), `onboarding.secrets.s3.s3-user-secret`,
+and `onboarding.volumes.reports` (an `nfs-csi` `ReadWriteMany` PVC
+mounted at `/home/mosip/reports` — this is where the container's
+`./reports` output actually lands in a cluster deployment, versus the
+local `-v` bind mount used in the root `AGENTS.md`'s `docker run`
+example).
+
+## `README.md` caveat
+
+The chart's `README.md` TL;DR (`helm repo add mosip
+https://mosip.github.io` then `helm install my-release
+mosip/partner-onboarder`) is unverified generic chart-starter
+boilerplate — other MOSIP repos' actual install scripts use
+`https://mosip.github.io/mosip-helm` as the repo URL, not the bare
+`https://mosip.github.io`. Don't copy this README's `helm repo add`
+command as-is without checking the real repo URL; `../deploy/install.sh`
+doesn't run `helm repo add` at all (it assumes the `mosip` repo is
+already added and just runs `helm repo update`).
+
+## Agent rules
+
+### Do
+
+1. Edit `../deploy/values.yaml` to change which onboarding modules run
+   — not this chart's own `values.yaml`, which only matters for a
+   standalone `helm install` without `-f`.
+2. Add a new module's `name`/`enabled` entry to both `values.yaml`
+   files if you want the chart usable both standalone and via
+   `../deploy/install.sh`.
+
+### Do not
+
+1. Do not assume `values.yaml`'s module list here is what actually runs
+   when installed via `../deploy/install.sh` — that script's own
+   `values.yaml` replaces it entirely.
+2. Do not copy `README.md`'s `helm repo add https://mosip.github.io`
+   command without verifying the actual repo URL first.


### PR DESCRIPTION
Addresses https://github.com/mosip/mosip-config/issues/10670 — adds a root AGENTS.md covering repository overview, tech stack, build/test commands, configuration, project structure, development workflow, PR guidelines, and repo-specific considerations for AI coding assistants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive repository guidance covering its purpose, technology stack, project structure, build and validation commands, and development workflows.
  * Documented operational considerations, including secret handling, certificate synchronization, Postman dependencies, branching conventions, and validation options.
  * Added onboarding guidance for shell, Newman, Docker, and Helm workflows, along with pull request practices and agent-specific rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->